### PR TITLE
#55752 Rollback euiInputSelect (war dauerhaft rot)

### DIFF
--- a/Template/Elements/euiInputSelect.php
+++ b/Template/Elements/euiInputSelect.php
@@ -16,7 +16,7 @@ class euiInputSelect extends euiInput {
 					<option value="' . $value . '"' . ($this->get_value_with_defaults() == $value ? ' selected="selected"' : '') . '>' . $text . '</option>';
 		}
 
-		$output = '	<select style="height: 100%; width: 100%;" class="textbox textbox-text textbox-prompt' . ($widget->is_required() ? ' validatebox-invalid' : '') . '"
+		$output = '	<select style="height: 100%; width: 100%;" class="textbox textbox-text textbox-prompt"
 						name="' . $widget->get_attribute_alias() . '"  
 						id="' . $this->get_id() . '"  
 						' . ($widget->is_required() ? 'required="true" ' : '') . '


### PR DESCRIPTION
Egal ob eine Eingabe gemacht wurde oder nicht war die Box rot (bei einem benoetigten
Parameter).