### PR TITLE
#29582 Timestampingbehavior fuer Massenoperationen

### DIFF
--- a/Template/Elements/euiInputHidden.php
+++ b/Template/Elements/euiInputHidden.php
@@ -10,18 +10,9 @@ class euiInputHidden extends euiInput {
 	function generate_html(){
 		$output = '<input type="hidden" 
 								name="' . $this->get_widget()->get_attribute_alias() . '" 
-								value="' . $this->get_value() . '" 
+								value="' . $this->get_value_with_defaults() . '" 
 								id="' . $this->get_id() . '" />';
 		return $output;
-	}
-	
-	function get_value() {
-		if ($this->get_widget()->get_value_expression() && $this->get_widget()->get_value_expression()->is_reference()){
-			$value = '';
-		} else {
-			$value = $this->get_widget()->get_value();
-		}
-		return $this->escape_string($value);
 	}
 	
 	function generate_js(){

--- a/Template/Elements/euiInputHidden.php
+++ b/Template/Elements/euiInputHidden.php
@@ -10,9 +10,18 @@ class euiInputHidden extends euiInput {
 	function generate_html(){
 		$output = '<input type="hidden" 
 								name="' . $this->get_widget()->get_attribute_alias() . '" 
-								value="' . $this->get_value_with_defaults() . '" 
+								value="' . $this->get_value() . '" 
 								id="' . $this->get_id() . '" />';
 		return $output;
+	}
+	
+	function get_value() {
+		if ($this->get_widget()->get_value_expression() && $this->get_widget()->get_value_expression()->is_reference()){
+			$value = '';
+		} else {
+			$value = $this->get_widget()->get_value();
+		}
+		return $this->escape_string($value);
 	}
 	
 	function generate_js(){

--- a/Template/Elements/euiInputSelect.php
+++ b/Template/Elements/euiInputSelect.php
@@ -16,7 +16,7 @@ class euiInputSelect extends euiInput {
 					<option value="' . $value . '"' . ($this->get_value_with_defaults() == $value ? ' selected="selected"' : '') . '>' . $text . '</option>';
 		}
 
-		$output = '	<select style="height: 100%; width: 100%;" class="textbox textbox-text textbox-prompt"
+		$output = '	<select style="height: 100%; width: 100%;" class="easyui-' . $this->get_element_type() . '" 
 						name="' . $widget->get_attribute_alias() . '"  
 						id="' . $this->get_id() . '"  
 						' . ($widget->is_required() ? 'required="true" ' : '') . '


### PR DESCRIPTION
Wenn bei einem Massenupdate keine Zeile ausgewählt war, das Widget also über die Filter vorgefüllt wurde, gab es trotzdem einen eingetragenen Wert für TS_UPDATE. Das lag daran, dass dafür ein default Wert gesetzt wurde der gleich dem jetzigen Zeitpunkt ist. Um das zu unterdrücken habe ich euiInputHidden so verändert, dass dort keine default oder fixed Werte vorgefüllt werden, ist das in Ordnung?