### PR TITLE
#56443 Anzeige des Status als Pflichtfeld

### DIFF
--- a/Template/Elements/euiInputSelect.php
+++ b/Template/Elements/euiInputSelect.php
@@ -32,5 +32,9 @@ class euiInputSelect extends euiInput {
 		$output = '';
 		return $output;
 	}
+	
+	public function build_js_value_getter(){
+		return "$('#" . $this->get_id() . "')." . $this->get_element_type() . "('getValue')";
+	}
 }
 ?>


### PR DESCRIPTION
Der Inhalt des Statusfeldes wurde beim Erzeugen von Objekten nicht
ausgelesen.