### PR TITLE
#FIX Spaltenzahl DataConfiguratorWidget nicht vererbt

### DIFF
--- a/Template/Elements/euiDataConfigurator.php
+++ b/Template/Elements/euiDataConfigurator.php
@@ -12,9 +12,9 @@ use exface\AbstractAjaxTemplate\Template\Elements\JqueryDataConfiguratorTrait;
  *
  */
 class euiDataConfigurator extends euiTabs
-{    
+{
     use JqueryDataConfiguratorTrait;
-    
+
     /**
      * Returns the default number of columns to layout this widget.
      *
@@ -23,6 +23,16 @@ class euiDataConfigurator extends euiTabs
     public function getDefaultColumnNumber()
     {
         return $this->getTemplate()->getConfig()->getOption("WIDGET.DATACONFIGURATOR.COLUMNS_BY_DEFAULT");
+    }
+
+    /**
+     * 
+     * {@inheritDoc}
+     * @see \exface\JEasyUiTemplate\Template\Elements\euiTabs::inheritsColumnNumber()
+     */
+    public function inheritsColumnNumber()
+    {
+        return false;
     }
 }
 ?>

--- a/Template/Elements/euiTab.php
+++ b/Template/Elements/euiTab.php
@@ -94,5 +94,20 @@ JS;
         }
         return parent::getDefaultColumnNumber();
     }
+
+    /**
+     * If the tab inherits the column number from a parent layout widget is defined for
+     * the tabs widget or its derivatives.
+     *
+     * @return boolean
+     */
+    public function inheritsColumnNumber()
+    {
+        $parent_element = $this->getTemplate()->getElement($this->getWidget()->getParent());
+        if (method_exists($parent_element, 'inheritsColumnNumber')) {
+            return $parent_element->inheritsColumnNumber();
+        }
+        return parent::inheritsColumnNumber();
+    }
 }
 ?>

--- a/Template/Elements/euiTabs.php
+++ b/Template/Elements/euiTabs.php
@@ -81,6 +81,17 @@ HTML;
         return $this->getTemplate()->getConfig()->getOption("WIDGET.TABS.COLUMNS_BY_DEFAULT");
     }
 
+    /**
+     * Determines if the tabs in this widget inherit their column number from a parent
+     * layout widget.
+     *
+     * @return boolean
+     */
+    public function inheritsColumnNumber()
+    {
+        return true;
+    }
+
     public function addOnResizeScript($js)
     {
         foreach ($this->getWidget()->getTabs() as $tab) {


### PR DESCRIPTION
Tab ist im Prinzip ein Panel und erbt damit die Spaltenzahl eines uebergeordneten Layout-Widgets. In einem Fall war die DataTable in einem Dashboard und das DataConfiguratorWidget erbte die Spaltenzahl des Dashboards. Jetzt erbt das DataConfiguratorWidget die Spaltenzahl nicht mehr, sondern nur noch das TabsWidgets.
