### PR TITLE
attach an unselectAll-Event zu reset previous table selections

### DIFF
--- a/Template/Elements/euiDataTable.php
+++ b/Template/Elements/euiDataTable.php
@@ -204,7 +204,13 @@ HTML;
      */
     public function buildJsRefresh($keep_pagination_position = false)
     {
-        return '$("#' . $this->getId() . '").' . $this->getElementType() . '("' . ($keep_pagination_position ? 'reload' : 'load') .'")';
+        $keepPaginationScript = $keep_pagination_position ? 'reload' : 'load';
+        $output = <<<JS
+
+            $("#{$this->getId()}").{$this->getElementType()}("{$keepPaginationScript}");
+            $("#{$this->getId()}").{$this->getElementType()}("unselectAll");
+JS;
+        return $output;
     }
 
     /**


### PR DESCRIPTION
Wird eine Tabelle nach einer Action automatisch neu geladen, so bleiben die alten Selektionen bestehen, obwohl die entsprechenden Zeilen nicht mehr im Suchergebnis und damit in der Tabelle existieren.